### PR TITLE
Cast integer values from config to string

### DIFF
--- a/src/Bridge/Symfony/DependencyInjection/NexyPayboxDirectExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/NexyPayboxDirectExtension.php
@@ -59,7 +59,7 @@ final class NexyPayboxDirectExtension extends Extension
 
         // Convert paybox option format
         foreach ($config['paybox'] as $key => $value) {
-            $options['paybox_'.$key] = $value;
+            $options['paybox_'.$key] = (string) $value;
         }
 
         $container->setParameter('nexy_paybox_direct.options', $options);

--- a/tests/Bridge/Symfony/DependencyInjection/NexyPayboxDirectExtensionTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/NexyPayboxDirectExtensionTest.php
@@ -111,9 +111,9 @@ class NexyPayboxDirectExtensionTest extends AbstractExtensionTestCase
         return [
             'paybox' => [
                 'version' => 'direct_plus',
-                'site' => '1999888',
-                'rank' => '32',
-                'identifier' => '107904482',
+                'site' => 1999888,
+                'rank' => 32,
+                'identifier' => 107904482,
                 'key' => '1999888I',
             ],
         ];


### PR DESCRIPTION
If you set a config like this:

``` yml
nexy_paybox_direct:
  paybox:
    version: direct_plus
    site: 1999888
    rank: 32
    identifier: 107904482
    key: 1999888I
```

site, rank and identifier will be returned as integer.

The Paybox class option resolver wants only string values.

So we cast each value to string to be sure the configuration will pass.
