### PR TITLE
Prefer random_int for random question number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "doctrine/cache": "^1.0",
         "greg0ire/enum": "^2.1 || ^3.0",
         "guzzlehttp/guzzle": "^6.0",
+        "paragonie/random_compat": "^2.0",
         "symfony/options-resolver": "^2.7 || ^3.0",
         "symfony/validator": "^2.7 || ^3.0"
     },

--- a/src/HttpClient/AbstractHttpClient.php
+++ b/src/HttpClient/AbstractHttpClient.php
@@ -57,7 +57,11 @@ abstract class AbstractHttpClient
      */
     final public function __construct()
     {
-        $this->questionNumber = rand(0, time());
+        try {
+            $this->questionNumber = random_int(0, time());
+        } catch (\Exception $exception) {
+            $this->questionNumber = rand(0, time());
+        }
     }
 
     /**


### PR DESCRIPTION
This method is more secure than rand.

A fallback to rand will be done if random_int can not be performed.