### PR TITLE
Support Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "doctrine/annotations": "^1.2",
         "doctrine/cache": "^1.0",
         "greg0ire/enum": "^2.1 || ^3.0 || ^4.0",
-        "guzzlehttp/guzzle": "^6.5",
+        "guzzlehttp/guzzle": "^6.5 || ^7.0",
         "paragonie/random_compat": "^2.0",
         "symfony/options-resolver": "^4.0",
         "symfony/validator": "^4.0 || ^5.0"


### PR DESCRIPTION
Recent laravel versions require Guzzle 7, have adjusted composer to allow both 6.5 and 7.0 versions